### PR TITLE
feat: support compiled es modules

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -97,6 +97,30 @@ Error: ./fixtures/error-thrower.macro: very unhelpful
 
 `;
 
+exports[`macros supports compiled macros (\`__esModule\` + \`export default\`): supports compiled macros (\`__esModule\` + \`export default\`) 1`] = `
+
+import {css, styled} from './fixtures/emotion-esm.macro'
+const red = css\`
+  background-color: red;
+\`
+
+const Div = styled.div\`
+  composes: \${red}
+  color: blue;
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const red = css\`
+  background-color: red;
+\`;
+const Div = styled.div\`
+  composes: \${red}
+  color: blue;
+\`;
+
+`;
+
 exports[`macros supports macros from node_modules: supports macros from node_modules 1`] = `
 
 import fakeMacro from 'babel-plugin-macros-test-fake/macro'

--- a/src/__tests__/fixtures/emotion-esm.macro.js
+++ b/src/__tests__/fixtures/emotion-esm.macro.js
@@ -1,0 +1,8 @@
+const {createMacro} = require('../../')
+
+export default createMacro(evalMacro)
+
+function evalMacro() {
+  // we're lazy right now
+  // we don't want to eval
+}

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -129,6 +129,20 @@ pluginTester({
       `,
     },
     {
+      title: 'supports compiled macros (`__esModule` + `export default`)',
+      code: `
+        import {css, styled} from './fixtures/emotion-esm.macro'
+        const red = css\`
+          background-color: red;
+        \`
+
+        const Div = styled.div\`
+          composes: \${red}
+          color: blue;
+        \`
+      `,
+    },
+    {
       title: 'supports macros from node_modules',
       code: `
         import fakeMacro from 'babel-plugin-macros-test-fake/macro'

--- a/src/index.js
+++ b/src/index.js
@@ -134,8 +134,7 @@ function applyMacros({path, imports, source, state, babel}) {
   if (isRelative) {
     requirePath = p.join(p.dirname(getFullFilename(filename)), source)
   }
-  // eslint-disable-next-line import/no-dynamic-require
-  const macro = require(requirePath)
+  const macro = interopRequire(requirePath)
   if (!macro.isBabelMacro) {
     throw new Error(
       // eslint-disable-next-line prefer-template
@@ -233,6 +232,12 @@ function looksLike(a, b) {
 function isPrimitive(val) {
   // eslint-disable-next-line
   return val == null || /^[sbn]/.test(typeof val)
+}
+
+function interopRequire(path) {
+  // eslint-disable-next-line import/no-dynamic-require
+  const o = require(path)
+  return o && o.__esModule && o.default ? o.default : o
 }
 
 module.exports = macrosPlugin


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Macros exported with `export default createMacro(...)` and compiled to commonjs are currently not supported. Trying to use one results in this error:

```
The macro imported from "./fixtures/esm-export.macro.js" must be wrapped
in "createMacro" which you can get from "babel-plugin-macros". Please refer
to the documentation to see how to do this properly:
https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/author.md#writing-a-macro
```

<!-- Why are these changes necessary? -->

**Why**:

If the rest of the macro project is using `import` & `export`, it's a bit of a bummer to use `module.exports = createMacro(...)`.

<!-- How were these changes implemented? -->

**How**:

Use a helper similar to Babel's own `_interopRequireDefault` that checks for the `__esModule` flag on the module and returns its `default` property if it exists, else returns the `require`d object itself to maintain commonjs support.

<!-- feel free to add additional comments -->
