### PR TITLE
add raw.macro to the list of existing macro

### DIFF
--- a/other/docs/macros.md
+++ b/other/docs/macros.md
@@ -16,6 +16,7 @@ there's an ecosystem of existing macros out there that you might find interestin
 * [`graphql.macro`](https://github.com/evenchange4/graphql.macro): Compile GraphQL AST at build-time with babel-plugin-macros.
 * [`svgr.macro`](https://github.com/evenchange4/svgr.macro): Run svgr at build-time with babel-plugin-macros.
 * [`glamorous.macro`](https://github.com/kentcdodds/glamorous.macro): Give your glamorous components a nice `displayName` for React DevTools.
+* [`raw.macro`](https://github.com/pveyes/raw.macro): Webpack raw-loader implemented with babel-plugin-macros.
 
 Please note that macros are intended to be used as devDependencies.
 


### PR DESCRIPTION
**What**:

`raw.macro` is a babel macro to read file contents at build time (similar to webpack `raw-loader`). This could be useful in environment where webpack is not available / not extensible (for example new `create-react-app` with babel-plugin-macro built-in)

**Why**:

As suggested in twitter https://twitter.com/kentcdodds/status/964860739033772032

**How**:

I created this PR via GitHub desktop UI (including commiting this change) so maybe there's something missing. I also think I don't need to add myself as contributor because this is just a minor update not affecting babel-plugin-macros itself