### PR TITLE
Call macro function even if references are empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-plugin-tester": "^5.0.0",
     "babel-types": "^6.26.0",
     "babylon": "7.0.0-beta.34",
-    "cpy": "^6.0.0",
+    "cpy": "^7.0.0",
     "kcd-scripts": "^0.32.1"
   },
   "eslintConfig": {

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -52,17 +52,6 @@ Error: babel-plugin-macros-test-error-thrower.macro: not helpful Learn more: htt
 
 `;
 
-exports[`macros does nothing but remove macros if it is unused: does nothing but remove macros if it is unused 1`] = `
-
-import foo from './some-macros-that-doesnt-even-need-to-exist.macro'
-export default 'something else'
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-export default 'something else';
-
-`;
-
 exports[`macros forwards MacroErrors thrown by the macro: forwards MacroErrors thrown by the macro 1`] = `
 
 import errorThrower from './fixtures/macro-error-thrower.macro'
@@ -94,6 +83,17 @@ errorThrower('hey')
       ↓ ↓ ↓ ↓ ↓ ↓
 
 Error: ./fixtures/error-thrower.macro: very unhelpful
+
+`;
+
+exports[`macros removes macro even if unused: removes macro even if unused 1`] = `
+
+import myEval from './fixtures/eval.macro'
+export default 'something else'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export default 'something else';
 
 `;
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -52,9 +52,9 @@ pluginTester({
       `,
     },
     {
-      title: 'does nothing but remove macros if it is unused',
+      title: 'removes macro even if unused',
       code: `
-        import foo from './some-macros-that-doesnt-even-need-to-exist.macro'
+        import myEval from './fixtures/eval.macro'
         export default 'something else'
       `,
     },

--- a/src/index.js
+++ b/src/index.js
@@ -129,18 +129,13 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
       opts: {filename},
     },
   } = state
-  let hasReferences = false
   const referencePathsByImportName = imports.reduce(
     (byName, {importedName, localName}) => {
       byName[importedName] = path.scope.getBinding(localName).referencePaths
-      hasReferences = hasReferences || Boolean(byName[importedName].length)
       return byName
     },
     {},
   )
-  if (!hasReferences) {
-    return
-  }
   let requirePath = source
   const isRelative = source.indexOf('.') === 0
   if (isRelative) {


### PR DESCRIPTION
**What**:
This PR removes the early exit from `applyMacros` if no references are found for the import. Effectively, this means that a macro function, if imported, will always be called at least once.

**Why**:
I'm working on writing a macro for [babel-plugin-trace](/codemix/babel-plugin-trace), which repurposes JavaScript's [LabeledStatements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label) for logging calls that are by default only compiled in development mode. These statements don't share namespace with anything else, so they're also not returned by the `path.scope.getBinding(localName)` call.

An alternative solution that could be sufficient for my particular case would be to also check `path.scope.getLabel(localName)` in the loop, but this could create a conflict as, again, the namespaces for variable bindings and labels are separate. Leaving out the early return also enables an easier API to be used by other macros, as well as this case.

With the current API, this would already be possible (using `state.file.path.traverse`, and removing the `initTrace()` call from the AST):

```js
// file.js
import initTrace from 'babel-plugin-trace/macro'
initTrace()

function fun() {
  log: 'This is fun!'
  return 42
}

fun()

// logs when transpiled in dev mode & then run:
//   file:fun: This is fun!
```

With this PR, the first two lines could be replaced with:
```js
import 'babel-plugin-trace/macro'
```

I also had to update the `cpy` dependency to v7 as v6 doesn't work with node v10.