### PR TITLE
feat(source param): Call macro with additional source parameter

### DIFF
--- a/.eslintcache
+++ b/.eslintcache
@@ -1,1 +1,0 @@
-{"/Users/mateuszburzynski/Desktop/babel-plugin-macros/src/__tests__/index.js":{"size":7797,"mtime":1531302441000,"hashOfConfig":"19k0y1k","results":{"filePath":"/Users/mateuszburzynski/Desktop/babel-plugin-macros/src/__tests__/index.js","messages":[],"errorCount":0,"warningCount":0,"fixableErrorCount":0,"fixableWarningCount":0}}}

--- a/.eslintcache
+++ b/.eslintcache
@@ -1,0 +1,1 @@
+{"/Users/mateuszburzynski/Desktop/babel-plugin-macros/src/__tests__/index.js":{"size":7797,"mtime":1531302441000,"hashOfConfig":"19k0y1k","results":{"filePath":"/Users/mateuszburzynski/Desktop/babel-plugin-macros/src/__tests__/index.js","messages":[],"errorCount":0,"warningCount":0,"fixableErrorCount":0,"fixableWarningCount":0}}}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .opt-in
 .opt-out
 package-lock.json
+.eslintcache

--- a/other/docs/author.md
+++ b/other/docs/author.md
@@ -158,6 +158,10 @@ you're given. For that check out [the babel handbook][babel-handbook].
 > One other thing to note is that after your macro has run, babel-plugin-macros will
 > remove the import/require statement for you.
 
+#### source
+
+This is a string used as import declaration's source - i.e. `'./my.macro'`.
+
 #### config (EXPERIMENTAL!)
 
 There is an experimental feature that allows users to configure your macro. We

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -152,12 +152,12 @@ pluginTester({
         // kinda abusing the babel-plugin-tester API here
         // to make an extra assertion
         // eslint-disable-next-line
-        const fakeMacro = require('babel-plugin-macros-test-fake/macros')
+        const fakeMacro = require('babel-plugin-macros-test-fake/macro')
         expect(fakeMacro.innerFn).toHaveBeenCalledTimes(1)
         expect(fakeMacro.innerFn).toHaveBeenCalledWith({
           references: expect.any(Object),
           source: expect.stringContaining(
-            'babel-plugin-macros-test-fake/macros',
+            'babel-plugin-macros-test-fake/macro',
           ),
           state: expect.any(Object),
           babel: expect.any(Object),

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -152,10 +152,13 @@ pluginTester({
         // kinda abusing the babel-plugin-tester API here
         // to make an extra assertion
         // eslint-disable-next-line
-        const fakeMacro = require('babel-plugin-macros-test-fake/macro')
+        const fakeMacro = require('babel-plugin-macros-test-fake/macros')
         expect(fakeMacro.innerFn).toHaveBeenCalledTimes(1)
         expect(fakeMacro.innerFn).toHaveBeenCalledWith({
           references: expect.any(Object),
+          source: expect.stringContaining(
+            'babel-plugin-macros-test-fake/macros',
+          ),
           state: expect.any(Object),
           babel: expect.any(Object),
           isBabelMacrosCall: true,

--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,7 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
 
     macro({
       references: referencePathsByImportName,
+      source,
       state,
       babel,
       config,


### PR DESCRIPTION
Useful for relative macro paths - when I want to convert a macro import to sibling, regular, file.