### PR TITLE
Allow macros to keep imports

### DIFF
--- a/other/docs/author.md
+++ b/other/docs/author.md
@@ -202,6 +202,26 @@ module.exports = {
 
 And the `config` object you would receive would be: `{someConfig: {}}`.
 
+### Keeping imports
+
+As said before, `babel-plugin-macros` automatically removes an import statement
+of macro. If you want to keep it because you have other plugins processing
+macros, return `{ keepImports: true }` from your macro:
+
+```javascript
+const {createMacro} = require('babel-plugin-macros')
+
+module.exports = createMacro(taggedTranslationsMacro)
+
+function taggedTranslationsMacro({references, state, babel}) {
+  // process node from references
+
+  return {
+    keepImports: true,
+  }
+}
+```
+
 ## Throwing Helpful Errors
 
 Debugging stuff that transpiles your code is the worst, especially for

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "cosmiconfig": "4.0.0"
+    "cosmiconfig": "^5.0.5"
   },
   "devDependencies": {
     "ast-pretty-print": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "cosmiconfig": "^4.0.0"
+    "cosmiconfig": "4.0.0"
   },
   "devDependencies": {
     "ast-pretty-print": "^2.0.1",
@@ -36,7 +36,7 @@
     "babel-plugin-tester": "^5.0.0",
     "babel-types": "^6.26.0",
     "babylon": "7.0.0-beta.34",
-    "cpy": "^6.0.0",
+    "cpy": "^7.0.0",
     "kcd-scripts": "^0.32.1"
   },
   "eslintConfig": {

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -86,7 +86,19 @@ configured\`stuff\`;
 
 `;
 
-exports[`macros optionally keep imports: optionally keep imports 1`] = `
+exports[`macros optionally keep imports (import declaration): optionally keep imports (import declaration) 1`] = `
+
+import macro from './fixtures/keep-imports.macro'
+const red = macro('noop');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import macro from './fixtures/keep-imports.macro';
+const red = macro('noop');
+
+`;
+
+exports[`macros optionally keep imports (variable assignment): optionally keep imports (variable assignment) 1`] = `
 
 const macro = require('./fixtures/keep-imports.macro')
 const red = macro('noop');

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -86,6 +86,19 @@ configured\`stuff\`;
 
 `;
 
+exports[`macros optionally keep imports: optionally keep imports 1`] = `
+
+const macro = require('./fixtures/keep-imports.macro')
+const red = macro('noop');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const macro = require('./fixtures/keep-imports.macro');
+
+const red = macro('noop');
+
+`;
+
 exports[`macros prepends the relative path for errors thrown by the macro: prepends the relative path for errors thrown by the macro 1`] = `
 
 import errorThrower from './fixtures/error-thrower.macro'

--- a/src/__tests__/fixtures/keep-imports.macro.js
+++ b/src/__tests__/fixtures/keep-imports.macro.js
@@ -1,0 +1,7 @@
+const {createMacro} = require('../../')
+
+module.exports = createMacro(keepImportMacro)
+
+function keepImportMacro() {
+  return {keepImports: true}
+}

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -167,9 +167,16 @@ pluginTester({
       },
     },
     {
-      title: 'optionally keep imports',
+      title: 'optionally keep imports (variable assignment)',
       code: `
         const macro = require('./fixtures/keep-imports.macro')
+        const red = macro('noop');
+      `,
+    },
+    {
+      title: 'optionally keep imports (import declaration)',
+      code: `
+        import macro from './fixtures/keep-imports.macro'
         const red = macro('noop');
       `,
     },

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -167,6 +167,13 @@ pluginTester({
       },
     },
     {
+      title: 'optionally keep imports',
+      code: `
+        const macro = require('./fixtures/keep-imports.macro')
+        const red = macro('noop');
+      `,
+    },
+    {
       title: 'throws an error if the macro is not properly wrapped',
       error: true,
       code: `


### PR DESCRIPTION
Closes #74, review welcome :)


Btw I'm still getting errors when running tests locally. After I fork and clone repo, run `npm run setup -s` I see a lot of failed tests. Most of them with following error:

```
  ● macros › does nothing to code that does not import macro

    TypeError: Cannot read property 'mockClear' of undefined

      23 | afterEach(() => {
      24 |   // eslint-disable-next-line
    > 25 |   require('babel-plugin-macros-test-fake/macro').innerFn.mockClear()
      26 | })
      27 |
      28 | expect.addSnapshotSerializer({
```

Also few failed snapshots:

```
  ● macros › when a plugin that replaces paths is used, macros still work properly

    expect(value).toMatchSnapshot()

    Received value does not match stored snapshot 1.

    - Snapshot
    + Received

    @@ -4,7 +4,7 @@

      global.result = result

            ↓ ↓ ↓ ↓ ↓ ↓

    - const result = ("foobar", 42);
    + const result = 42;
      global.result = result;
```

My environment:

`node --version`: v10.7.0
`npm --version`: 6.2.0