### PR TITLE
Skip invalid imports

### DIFF
--- a/other/mock-modules/babel-plugin-path-replace/index.js
+++ b/other/mock-modules/babel-plugin-path-replace/index.js
@@ -1,4 +1,4 @@
-const types = require('babel-types')
+const types = require('@babel/types')
 
 const problematicVisitor = {
   VariableDeclarator: {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "@babel/core": "^7.1.0",
     "ast-pretty-print": "^2.0.1",
     "babel-plugin-tester": "^5.0.0",
-    "babel-types": "^6.26.0",
-    "babylon": "^6.18.0",
     "cpy": "^7.0.0",
     "kcd-scripts": "^0.32.1"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",
+    "@babel/parser": "^7.1.0",
+    "@babel/types": "^7.0.0",
     "ast-pretty-print": "^2.0.1",
     "babel-plugin-tester": "^5.0.0",
     "cpy": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "cosmiconfig": "^5.0.5"
   },
   "devDependencies": {
+    "@babel/core": "^7.1.0",
     "ast-pretty-print": "^2.0.1",
-    "babel-core": "7.0.0-beta.3",
     "babel-plugin-tester": "^5.0.0",
     "babel-types": "^6.26.0",
-    "babylon": "7.0.0-beta.34",
+    "babylon": "^6.18.0",
     "cpy": "^7.0.0",
     "kcd-scripts": "^0.32.1"
   },

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -120,6 +120,8 @@ const red = macro('noop')
 
 "use strict";
 
+var _keepImports = require("./fixtures/keep-imports.macro");
+
 var _keepImports2 = _interopRequireDefault(_keepImports);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -15,6 +15,7 @@ const Div = STYLED.div\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const red = "background-color: red;";
+
 const Div = STYLED.div\`undefined\`;
 
 `;
@@ -106,8 +107,24 @@ const red = macro('noop');
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const macro = require('./fixtures/keep-imports.macro');
-
 const red = macro('noop');
+
+`;
+
+exports[`macros optionally keep imports in combination with babel-preset-env (#80): optionally keep imports in combination with babel-preset-env (#80) 1`] = `
+
+import macro from './fixtures/keep-imports.macro'
+const red = macro('noop')
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+"use strict";
+
+var _keepImports2 = _interopRequireDefault(_keepImports);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var red = (0, _keepImports2.default)('noop');
 
 `;
 
@@ -139,6 +156,7 @@ const Div = styled.div\`
 const red = css\`
   background-color: red;
 \`;
+
 const Div = styled.div\`
   composes: \${red}
   color: blue;
@@ -179,6 +197,7 @@ global.result = result
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const result = ("foobar", 42);
+
 global.result = result;
 
 `;
@@ -250,6 +269,7 @@ const Div = STYLED.div\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const red = "background-color: red;";
+
 const Div = STYLED.div\`undefined\`;
 
 `;
@@ -269,6 +289,7 @@ const Div = styled.div\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const red = "background-color: red;";
+
 const Div = styled.div\`undefined\`;
 
 `;

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -53,6 +53,18 @@ Error: babel-plugin-macros-test-error-thrower.macro: not helpful Learn more: htt
 
 `;
 
+exports[`macros does nothing but removes macros if it is unused: does nothing but removes macros if it is unused 1`] = `
+
+import foo from "./fixtures/eval.macro";
+
+const bar = 42;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const bar = 42;
+
+`;
+
 exports[`macros forwards MacroErrors thrown by the macro: forwards MacroErrors thrown by the macro 1`] = `
 
 import errorThrower from './fixtures/macro-error-thrower.macro'
@@ -130,7 +142,7 @@ Error: ./fixtures/error-thrower.macro: very unhelpful
 
 `;
 
-exports[`macros raises an error if macro does not ecist: raises an error if macro does not ecist 1`] = `
+exports[`macros raises an error if macro does not exist: raises an error if macro does not exist 1`] = `
 
 import foo from './some-macros-that-doesnt-even-need-to-exist.macro'
 export default 'something else'

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -53,17 +53,6 @@ Error: babel-plugin-macros-test-error-thrower.macro: not helpful Learn more: htt
 
 `;
 
-exports[`macros does nothing but remove macros if it is unused: does nothing but remove macros if it is unused 1`] = `
-
-import foo from './some-macros-that-doesnt-even-need-to-exist.macro'
-export default 'something else'
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-export default 'something else';
-
-`;
-
 exports[`macros forwards MacroErrors thrown by the macro: forwards MacroErrors thrown by the macro 1`] = `
 
 import errorThrower from './fixtures/macro-error-thrower.macro'
@@ -138,6 +127,17 @@ errorThrower('hey')
       ↓ ↓ ↓ ↓ ↓ ↓
 
 Error: ./fixtures/error-thrower.macro: very unhelpful
+
+`;
+
+exports[`macros raises an error if macro does not ecist: raises an error if macro does not ecist 1`] = `
+
+import foo from './some-macros-that-doesnt-even-need-to-exist.macro'
+export default 'something else'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+Error: Cannot find module '<PROJECT_ROOT>/src/__tests__/some-macros-that-doesnt-even-need-to-exist.macro' from 'index.js'
 
 `;
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -53,7 +53,7 @@ Error: babel-plugin-macros-test-error-thrower.macro: not helpful Learn more: htt
 
 `;
 
-exports[`macros does nothing but removes macros if it is unused: does nothing but removes macros if it is unused 1`] = `
+exports[`macros does nothing but remove macros if it is unused: does nothing but remove macros if it is unused 1`] = `
 
 import foo from "./fixtures/eval.macro";
 

--- a/src/__tests__/fixtures/eval.macro.js
+++ b/src/__tests__/fixtures/eval.macro.js
@@ -1,4 +1,4 @@
-const babylon = require('babylon')
+const {parse} = require('@babel/parser')
 // const printAST = require('ast-pretty-print')
 const {createMacro} = require('../../')
 
@@ -49,6 +49,6 @@ function evalToAST(value) {
 }
 
 function thingToAST(object) {
-  const fileNode = babylon.parse(`var x = ${JSON.stringify(object)}`)
+  const fileNode = parse(`var x = ${JSON.stringify(object)}`)
   return fileNode.program.body[0].declarations[0].init
 }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -62,7 +62,16 @@ pluginTester({
       `,
     },
     {
-      title: 'raises an error if macro does not ecist',
+      title: 'does nothing but removes macros if it is unused',
+      snapshot: true,
+      code: `
+        import foo from "./fixtures/eval.macro";
+
+        const bar = 42;
+      `,
+    },
+    {
+      title: 'raises an error if macro does not exist',
       error: true,
       code: `
         import foo from './some-macros-that-doesnt-even-need-to-exist.macro'

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -62,7 +62,8 @@ pluginTester({
       `,
     },
     {
-      title: 'does nothing but remove macros if it is unused',
+      title: 'raises an error if macro does not ecist',
+      error: true,
       code: `
         import foo from './some-macros-that-doesnt-even-need-to-exist.macro'
         export default 'something else'

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -62,7 +62,7 @@ pluginTester({
       `,
     },
     {
-      title: 'does nothing but removes macros if it is unused',
+      title: 'does nothing but remove macros if it is unused',
       snapshot: true,
       code: `
         import foo from "./fixtures/eval.macro";

--- a/src/index.js
+++ b/src/index.js
@@ -148,15 +148,20 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
     },
     {},
   )
-  if (!hasReferences) {
-    return null
-  }
+
   let requirePath = source
   const isRelative = source.indexOf('.') === 0
   if (isRelative) {
     requirePath = p.join(p.dirname(getFullFilename(filename)), source)
   }
-  const macro = interopRequire(requirePath)
+
+  let macro, result
+  try {
+    macro = interopRequire(requirePath)
+  } catch (e) {
+    return null
+  }
+
   if (!macro.isBabelMacro) {
     throw new Error(
       // eslint-disable-next-line prefer-template
@@ -166,7 +171,7 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
     )
   }
   const config = getConfig(macro, filename, source)
-  let result
+
   try {
     /**
      * Other plugins that run before babel-plugin-macros might use path.replace, where a path is

--- a/src/index.js
+++ b/src/index.js
@@ -137,8 +137,13 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
   let hasReferences = false
   const referencePathsByImportName = imports.reduce(
     (byName, {importedName, localName}) => {
-      byName[importedName] = path.scope.getBinding(localName).referencePaths
-      hasReferences = hasReferences || Boolean(byName[importedName].length)
+      const binding = path.scope.getBinding(localName)
+
+      if (binding) {
+        byName[importedName] = binding.referencePaths
+        hasReferences = hasReferences || Boolean(byName[importedName].length)
+      }
+
       return byName
     },
     {},

--- a/src/index.js
+++ b/src/index.js
@@ -155,13 +155,7 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
     requirePath = p.join(p.dirname(getFullFilename(filename)), source)
   }
 
-  let macro, result
-  try {
-    macro = interopRequire(requirePath)
-  } catch (e) {
-    return null
-  }
-
+  const macro = interopRequire(requirePath)
   if (!macro.isBabelMacro) {
     throw new Error(
       // eslint-disable-next-line prefer-template
@@ -172,6 +166,7 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
   }
   const config = getConfig(macro, filename, source)
 
+  let result
   try {
     /**
      * Other plugins that run before babel-plugin-macros might use path.replace, where a path is


### PR DESCRIPTION
**What**:

When macro is configured to keep imports, the import line is processed twice? which causes error `Cannot read property 'referencePaths' of undefined`.

Here's the repo to reproduce the bug: https://github.com/tricoder42/lingui-issue-328

**Why**:


`path.scope.getBinding(localName)` returns undefined for `localName === '_macro'`, which is the import of macro.

https://github.com/kentcdodds/babel-plugin-macros/blob/d319f1066a41b412f20eadbcd5230ce178614925/src/index.js#L140

**How**:

I've just added a guard that `referencePaths` isn't accessed on undefined.
