### PR TITLE
Add CRA note to caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Are you trying to make your own macros that works with `babel-plugin-macros`? Go
 
 #### Babel cache problem
 
+>**Note:** This issue is not present when used in Create React App.
+
 Most of the time you'll probably be using this with the babel cache enabled in webpack to rebuild faster. If your macro function is **not pure** which gets different output with same code (e.g., IO side effects) it will cause recompile mechanism fail. Unfortunately you'll also experience this problem while developing your macro as well. If there's not a change to the source code that's being transpiled, then babel will use the cache rather than running your macro again.
 
 For now, to force recompile the code you can simply add a cache busting comment in the file:


### PR DESCRIPTION
**What**:

Note that Create React App does not suffer from a common problem using Macros.

**Why**:

https://github.com/facebook/create-react-app/issues/2730#issuecomment-426550137

We don't want users thinking they have to purge the cache, as this will be very detrimental to their rebuild speed.
It's also important because these configuration values are out of their reach; ejecting to "fix" this would be unnecessary.