### PR TITLE
Order of application in non-macro transforms chain

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`macros Macros are applied in the order respecting plugins order: Macros are applied in the order respecting plugins order 1`] = `
+
+import Wrap from "./fixtures/jsx-id-prefix.macro";
+
+const bar = Wrap(<div id="d1"><p id="p1"></p></div>);
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const bar = Wrap(<div id="plugin-macro-d1"><p id="plugin-macro-p1"></p></div>);
+
+`;
+
 exports[`macros Supports named imports: Supports named imports 1`] = `
 
 import {css as CSS, styled as STYLED} from './fixtures/emotion.macro'

--- a/src/__tests__/fixtures/jsx-id-prefix.macro.js
+++ b/src/__tests__/fixtures/jsx-id-prefix.macro.js
@@ -1,0 +1,20 @@
+// adds "prefix-" to each `id` attribute
+const {createMacro} = require('../../')
+
+module.exports = createMacro(wrapWidget)
+
+function wrapWidget({references, babel}) {
+  const {types: t} = babel
+  references.default.forEach(wrap => {
+    wrap.parentPath.traverse({
+      JSXAttribute(path) {
+        const name = path.get('name')
+        if (t.isJSXIdentifier(name) && name.node.name === 'id') {
+          const value = path.get('value')
+          if (t.isStringLiteral(value))
+            value.replaceWith(t.stringLiteral(`macro-${value.node.value}`))
+        }
+      },
+    })
+  })
+}

--- a/src/__tests__/fixtures/jsx-id-prefix.plugin.js
+++ b/src/__tests__/fixtures/jsx-id-prefix.plugin.js
@@ -1,0 +1,23 @@
+// babel-plugin adding `plugin-` prefix to each "id" JSX attribute
+module.exports = main
+
+function main({types: t}) {
+  return {
+    visitor: {
+      // intentionally traversing from Program,
+      // if it matches JSXAttribute here the issue won't be reproduced
+      Program(progPath) {
+        progPath.traverse({
+          JSXAttribute(path) {
+            const name = path.get('name')
+            if (t.isJSXIdentifier(name) && name.node.name === 'id') {
+              const value = path.get('value')
+              if (t.isStringLiteral(value))
+                value.replaceWith(t.stringLiteral(`plugin-${value.node.value}`))
+            }
+          },
+        })
+      },
+    },
+  }
+}

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -315,5 +315,16 @@ pluginTester({
         babelrc: true,
       },
     },
+    {
+      title: 'Macros are applied in the order respecting plugins order',
+      code: `
+        import Wrap from "./fixtures/jsx-id-prefix.macro";
+
+        const bar = Wrap(<div id="d1"><p id="p1"></p></div>);
+      `,
+      babelOptions: {
+        presets: [{plugins: [require('./fixtures/jsx-id-prefix.plugin')]}],
+      },
+    },
   ],
 })

--- a/src/index.js
+++ b/src/index.js
@@ -146,10 +146,8 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
     (byName, {importedName, localName}) => {
       const binding = path.scope.getBinding(localName)
 
-      if (binding) {
-        byName[importedName] = binding.referencePaths
-        hasReferences = hasReferences || Boolean(byName[importedName].length)
-      }
+      byName[importedName] = binding.referencePaths
+      hasReferences = hasReferences || Boolean(byName[importedName].length)
 
       return byName
     },


### PR DESCRIPTION
This fixes the problem described in #95 

While I know the applied technique can be called controversial, but it doesn't contradict macros usage, where macros applications aren't merged. At the moment I cannot specify where to run the macro in babel plugins chain, while it is possible to do with plugins.

Here, for example, just printing plugin (pprint.macro.js):

```javascript
module.exports = require('babel-plugin-macros').createMacro(function({state}) {
  console.log(require("@babel/generator").default(state.file.scope.path.node).code)
})
```

I run it with:

```
$ npx babel --plugins babel-plugin-macros --presets @babel/preset-env input.js
```

And inside the input.js just a simple async generator function:

```javascript
import "./pprint.macro"

async function* fn1() {
  yield await hi
}

```

Since the plugin should run before the preset I would expect this macro to output the text unchanged. However, now it outputs result of another plugin from "preset-env" which converts async generators to generators. But the preset-env after also converts generators to plain functions with regenerator. So I've got a kind of half-baked AST.

This PR isolates babel-plugin-macros pass and thus I'd get what I expect exactly. Users can decide where to apply this plugin in other babel plugins chain and get predictable behavior.






