### PR TITLE
fix: add default empty filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,8 @@ function macrosPlugin(babel, {require: _require = require} = {}) {
 function applyMacros({path, imports, source, state, babel, interopRequire}) {
   const {
     file: {
-      opts: {filename},
+      // istanbul ignore next (pretty much only useful for astexplorer I think)
+      opts: {filename = ''},
     },
   } = state
   let hasReferences = false

--- a/src/index.js
+++ b/src/index.js
@@ -136,9 +136,9 @@ function macrosPlugin(babel, {require: _require = require} = {}) {
 
 // eslint-disable-next-line complexity
 function applyMacros({path, imports, source, state, babel, interopRequire}) {
+  /* istanbul ignore next (pretty much only useful for astexplorer I think) */
   const {
     file: {
-      // istanbul ignore next (pretty much only useful for astexplorer I think)
       opts: {filename = ''},
     },
   } = state


### PR DESCRIPTION
**What**: This defaults the filename variable to an empty string

<!-- Why are these changes necessary? -->

**Why**: ASTexplorer.net is not working for babel-plugin-macros because we need the filename and it's not being provided in that environment. I'd considered just making the fix there, but I suspect there are other situations where this could be helpful.

<!-- How were these changes implemented? -->

**How**: Using destructuring defaults

<!-- feel free to add additional comments -->
