### PR TITLE
Allow custom path resolve function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,14 @@ function createMacro(macro, options = {}) {
   }
 }
 
-function macrosPlugin(babel, {require: _require = require} = {}) {
+function nodeResolvePath(source, basedir) {
+  return resolve.sync(source, {basedir})
+}
+
+function macrosPlugin(
+  babel,
+  {require: _require = require, resolvePath = nodeResolvePath} = {},
+) {
   function interopRequire(path) {
     // eslint-disable-next-line import/no-dynamic-require
     const o = _require(path)
@@ -80,6 +87,7 @@ function macrosPlugin(babel, {require: _require = require} = {}) {
               state,
               babel,
               interopRequire,
+              resolvePath,
             })
 
             if (!result || !result.keepImports) {
@@ -121,6 +129,7 @@ function macrosPlugin(babel, {require: _require = require} = {}) {
                   state,
                   babel,
                   interopRequire,
+                  resolvePath,
                 })
 
                 if (!result || !result.keepImports) {
@@ -135,7 +144,15 @@ function macrosPlugin(babel, {require: _require = require} = {}) {
 }
 
 // eslint-disable-next-line complexity
-function applyMacros({path, imports, source, state, babel, interopRequire}) {
+function applyMacros({
+  path,
+  imports,
+  source,
+  state,
+  babel,
+  interopRequire,
+  resolvePath,
+}) {
   /* istanbul ignore next (pretty much only useful for astexplorer I think) */
   const {
     file: {
@@ -156,9 +173,7 @@ function applyMacros({path, imports, source, state, babel, interopRequire}) {
   )
 
   const isRelative = source.indexOf('.') === 0
-  const requirePath = resolve.sync(source, {
-    basedir: p.dirname(getFullFilename(filename)),
-  })
+  const requirePath = resolvePath(source, p.dirname(getFullFilename(filename)))
 
   const macro = interopRequire(requirePath)
   if (!macro.isBabelMacro) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allows the plugin to accept a custom path resolve function.

<!-- Why are these changes necessary? -->

**Why**:

ASTExplorer doesn't have access to the `fs` module, so it throws an error when attempting to use `resolve.sync`.

<!-- How were these changes implemented? -->

**How**:

A `resolvePath` option is added to `macrosPlugin`, which is a function that receives the `source` path string and the `basedir` directory string. If `resolvePath` is not provided, `resolve.sync` will be used.

<!-- feel free to add additional comments -->

**Notes:**

I didn't see any tests for the existing `require` option for `macrosPlugin`, so it wasn't immediately obvious how I should test this. While not a substitute for a proper test, I did link it to a local clone of ASTExplorer and it worked as expected.

Fixes #102 