### PR TITLE
add a github action to run unit tests on pull requests

### DIFF
--- a/.github/actions/unit-tests/Dockerfile
+++ b/.github/actions/unit-tests/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10
+
+LABEL "com.github.actions.name"="Unit tests"
+LABEL "com.github.actions.description"="Run npm via `npm run setup -s`"
+LABEL "com.github.actions.icon"="check"
+LABEL "com.github.actions.color"="blue"
+
+LABEL "maintainer"="voldemortensen <opensource@garthmortensen.com>"
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/.github/actions/unit-tests/entrypoint.sh
+++ b/.github/actions/unit-tests/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+npm run setup -s

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,8 @@
+workflow "pull request tests" {
+  on = "pull_request"
+  resolves = ["run tests"]
+}
+
+action "run tests" {
+  uses = "./.github/actions/unit-tests"
+}


### PR DESCRIPTION
**What**: This PR add a GitHub Action that run `npm run setup -s` when a pull request is submitted.

**Why**: This helps ensure code quality and testing standards are maintained.

**How**: With a Dockerfile and shell script.

`npm run setup -s` run build, lint, and test scripts. If any of these scripts fail they will return with a non-zero exit code and show as a failed check on a pull request.
