### PR TITLE
Allow macro config to come from plugin options in babel config.

### DIFF
--- a/other/docs/author.md
+++ b/other/docs/author.md
@@ -182,7 +182,7 @@ importing file:
 - `babelMacros` in `package.json`
 
 The content of the config will be merged with the content of the babel macros plugin
-options. Plugin options take priority.
+options. Config options take priority.
 
 All together specifying and using the config might look like this:
 
@@ -209,8 +209,8 @@ function taggedTranslationsMacro({references, state, babel, config}) {
 }
 ```
 
-Note that in the above example if both files were sepcified the finale locale value would
-be `en_GB`, since that is the value in the plugin options.
+Note that in the above example if both files were sepcified the final locale value would
+be `en_US`, since that is the value in the plugin config file.
 
 ### Keeping imports
 

--- a/other/docs/author.md
+++ b/other/docs/author.md
@@ -4,9 +4,9 @@
 
 Is this your first time working with ASTs? Here are some resources:
 
-* [Writing custom Babel and ESLint plugins with ASTs](https://youtu.be/VBscbcm2Mok?list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf): A 53 minute talk by [@kentcdodds](https://twitter.com/kentcdodds)
-* [babel-handbook](https://github.com/thejameskyle/babel-handbook): A guided handbook on how to use Babel and how to create plugins for Babel by [@thejameskyle](https://twitter.com/thejameskyle)
-* [Code Transformation and Linting](https://kentcdodds.com/workshops/#code-transformation-and-linting): A workshop (recording available on Frontend Masters) with exercises of making custom Babel and ESLint plugins
+- [Writing custom Babel and ESLint plugins with ASTs](https://youtu.be/VBscbcm2Mok?list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf): A 53 minute talk by [@kentcdodds](https://twitter.com/kentcdodds)
+- [babel-handbook](https://github.com/thejameskyle/babel-handbook): A guided handbook on how to use Babel and how to create plugins for Babel by [@thejameskyle](https://twitter.com/thejameskyle)
+- [Code Transformation and Linting](https://kentcdodds.com/workshops/#code-transformation-and-linting): A workshop (recording available on Frontend Masters) with exercises of making custom Babel and ESLint plugins
 
 ## Writing a macro
 
@@ -164,43 +164,53 @@ This is a string used as import declaration's source - i.e. `'./my.macro'`.
 
 #### config (EXPERIMENTAL!)
 
-There is an experimental feature that allows users to configure your macro. We
-use [`cosmiconfig`][cosmiconfig] to read a `babel-plugin-macros` configuration which
+There is an experimental feature that allows users to configure your macro.
+
+To specify that your plugin is configurable, you pass a `configName` to `createMacro`.
+
+A configuration is created from data combined from two sources:
+We use [`cosmiconfig`][cosmiconfig] to read a `babel-plugin-macros` configuration which
 can be located in any of the following files up the directories from the
 importing file:
 
-* `.babel-plugin-macrosrc`
-* `.babel-plugin-macrosrc.json`
-* `.babel-plugin-macrosrc.yaml`
-* `.babel-plugin-macrosrc.yml`
-* `.babel-plugin-macrosrc.js`
-* `babel-plugin-macros.config.js`
-* `babelMacros` in `package.json`
+- `.babel-plugin-macrosrc`
+- `.babel-plugin-macrosrc.json`
+- `.babel-plugin-macrosrc.yaml`
+- `.babel-plugin-macrosrc.yml`
+- `.babel-plugin-macrosrc.js`
+- `babel-plugin-macros.config.js`
+- `babelMacros` in `package.json`
 
-To specify that your plugin is configurable, you pass a `configName` to
-`createMacro`:
+The content of the config will be merged with the content of the babel macros plugin
+options. Plugin options take priority.
 
-```javascript
-const {createMacro} = require('babel-plugin-macros')
-const configName = 'taggedTranslations'
-module.exports = createMacro(taggedTranslationsMacro, {configName})
-function taggedTranslationsMacro({references, state, babel, config}) {
-  // config would be taggedTranslations portion of the config as loaded from `cosmiconfig`
-}
-```
-
-Then to configure this, users would do something like this:
+All together specifying and using the config might look like this:
 
 ```javascript
-// babel-plugin-macros.config.js
+// .babel-plugin-macros.config.js
 module.exports = {
-  taggedTranslations: {
-    someConfig: {},
-  },
+  taggedTranslations: { locale: 'en_US' }
+}
+
+// .babel.config.js
+module.exports = {
+  plugins: [
+    ['macros': {
+      taggedTranslations: { locale: 'en_GB' }
+    }]
+  ]
+}
+
+// taggedTranslations.macro.js
+const {createMacro} = require('babel-plugin-macros')
+module.exports = createMacro(taggedTranslationsMacro, {configName: 'taggedTranslations'})
+function taggedTranslationsMacro({references, state, babel, config}) {
+  const { locale = 'en' } = config;
 }
 ```
 
-And the `config` object you would receive would be: `{someConfig: {}}`.
+Note that in the above example if both files were sepcified the finale locale value would
+be `en_GB`, since that is the value in the plugin options.
 
 ### Keeping imports
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -258,7 +258,7 @@ configured\`stuff\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-Error: <PROJECT_ROOT>/src/__tests__/fixtures/primitive-config/babel-plugin-macros.config.js specified a configurableMacro config of type number, but the the macros plugin's options.configurableMacro did contain an object.Both configs must contain objects for their options to be mergeable.
+Error: <PROJECT_ROOT>/src/__tests__/fixtures/primitive-config/babel-plugin-macros.config.js specified a configurableMacro config of type object, but the the macros plugin's options.configurableMacro did contain an object. Both configs must contain objects for their options to be mergeable.
 
 `;
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -221,6 +221,47 @@ global.result = result;
 
 `;
 
+exports[`macros when configuration is specified in plugin options: when configuration is specified in plugin options 1`] = `
+
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`;
+
+`;
+
+exports[`macros when configuration is specified incorrectly in plugin options: when configuration is specified incorrectly in plugin options 1`] = `
+
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`;
+
+`;
+
+exports[`macros when plugin options configuration cannot be merged with file configuration: when plugin options configuration cannot be merged with file configuration 1`] = `
+
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+Error: <PROJECT_ROOT>/src/__tests__/fixtures/primitive-config/babel-plugin-macros.config.js specified a configurableMacro config of type number, but the the macros plugin's options.configurableMacro did contain an object.Both configs must contain objects for their options to be mergeable.
+
+`;
+
 exports[`macros when there is an error reading the config, a helpful message is logged 1`] = `
 Array [
   There was an error trying to load the config "configurableMacro" for the macro imported from "./configurable.macro. Please see the error thrown for more information.,

--- a/src/__tests__/fixtures/config/babel-plugin-macros.config.js
+++ b/src/__tests__/fixtures/config/babel-plugin-macros.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   configurableMacro: {
+    fileConfig: true,
     someConfig: true,
   },
 }

--- a/src/__tests__/fixtures/primitive-config/babel-plugin-macros.config.js
+++ b/src/__tests__/fixtures/primitive-config/babel-plugin-macros.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  configurableMacro: 4,
+}

--- a/src/__tests__/fixtures/primitive-config/code.js
+++ b/src/__tests__/fixtures/primitive-config/code.js
@@ -1,0 +1,4 @@
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured`stuff`

--- a/src/__tests__/fixtures/primitive-config/configurable.macro.js
+++ b/src/__tests__/fixtures/primitive-config/configurable.macro.js
@@ -1,0 +1,10 @@
+const {createMacro} = require('../../../../')
+
+const configName = 'configurableMacro'
+const realMacro = jest.fn()
+module.exports = createMacro(realMacro, {configName})
+// for testing purposes only
+Object.assign(module.exports, {
+  realMacro,
+  configName,
+})

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -307,6 +307,58 @@ pluginTester({
       },
     },
     {
+      title: 'when configuration is specified in plugin options',
+      pluginOptions: {
+        configurableMacro: {
+          someConfig: false,
+          somePluginConfig: true,
+        },
+      },
+      fixture: path.join(__dirname, 'fixtures/config/code.js'),
+      teardown() {
+        const configurableMacro = require('./fixtures/config/configurable.macro')
+        expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
+        expect(configurableMacro.realMacro).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: {
+              fileConfig: true,
+              someConfig: false,
+              somePluginConfig: true,
+            },
+          }),
+        )
+        configurableMacro.realMacro.mockClear()
+      },
+    },
+    {
+      title: 'when configuration is specified incorrectly in plugin options',
+      fixture: path.join(__dirname, 'fixtures/config/code.js'),
+      pluginOptions: {
+        configurableMacro: 2,
+      },
+      setup() {
+        return function teardown() {
+          const configurableMacro = require('./fixtures/config/configurable.macro')
+          expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
+          expect(configurableMacro.realMacro).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+              config: expect.any,
+            }),
+          )
+          configurableMacro.realMacro.mockClear()
+        }
+      },
+    },
+    {
+      title:
+        'when plugin options configuration cannot be merged with file configuration',
+      error: true,
+      fixture: path.join(__dirname, 'fixtures/primitive-config/code.js'),
+      pluginOptions: {
+        configurableMacro: {},
+      },
+    },
+    {
       title:
         'when a plugin that replaces paths is used, macros still work properly',
       fixture: path.join(

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -169,21 +169,26 @@ pluginTester({
         fakeMacro('hi')
       `,
       teardown() {
-        // kinda abusing the babel-plugin-tester API here
-        // to make an extra assertion
-        // eslint-disable-next-line
-        const fakeMacro = require('babel-plugin-macros-test-fake/macro')
-        expect(fakeMacro.innerFn).toHaveBeenCalledTimes(1)
-        expect(fakeMacro.innerFn).toHaveBeenCalledWith({
-          references: expect.any(Object),
-          source: expect.stringContaining(
-            'babel-plugin-macros-test-fake/macro',
-          ),
-          state: expect.any(Object),
-          babel: expect.any(Object),
-          isBabelMacrosCall: true,
-        })
-        expect(fakeMacro.innerFn.mock.calls[0].babel).toBe(babel)
+        try {
+          // kinda abusing the babel-plugin-tester API here
+          // to make an extra assertion
+          // eslint-disable-next-line
+          const fakeMacro = require('babel-plugin-macros-test-fake/macro')
+          expect(fakeMacro.innerFn).toHaveBeenCalledTimes(1)
+          expect(fakeMacro.innerFn).toHaveBeenCalledWith({
+            references: expect.any(Object),
+            source: expect.stringContaining(
+              'babel-plugin-macros-test-fake/macro',
+            ),
+            state: expect.any(Object),
+            babel: expect.any(Object),
+            isBabelMacrosCall: true,
+          })
+          expect(fakeMacro.innerFn.mock.calls[0].babel).toBe(babel)
+        } catch (e) {
+          console.error(e)
+          throw e
+        }
       },
     },
     {
@@ -258,15 +263,19 @@ pluginTester({
       title: 'macros can set their configName and get their config',
       fixture: path.join(__dirname, 'fixtures/config/code.js'),
       teardown() {
-        const babelMacrosConfig = require('./fixtures/config/babel-plugin-macros.config')
-        const configurableMacro = require('./fixtures/config/configurable.macro')
-        expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
-        expect(configurableMacro.realMacro).toHaveBeenCalledWith(
-          expect.objectContaining({
-            config: babelMacrosConfig[configurableMacro.configName],
-          }),
-        )
-        configurableMacro.realMacro.mockClear()
+        try {
+          const babelMacrosConfig = require('./fixtures/config/babel-plugin-macros.config')
+          const configurableMacro = require('./fixtures/config/configurable.macro')
+          expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
+          expect(configurableMacro.realMacro.mock.calls[0][0].config).toEqual(
+            babelMacrosConfig[configurableMacro.configName],
+          )
+
+          configurableMacro.realMacro.mockClear()
+        } catch (e) {
+          console.error(e)
+          throw e
+        }
       },
     },
     {
@@ -281,9 +290,14 @@ pluginTester({
         const originalError = console.error
         console.error = jest.fn()
         return function teardown() {
-          expect(console.error).toHaveBeenCalledTimes(1)
-          expect(console.error.mock.calls[0]).toMatchSnapshot()
-          console.error = originalError
+          try {
+            expect(console.error).toHaveBeenCalledTimes(1)
+            expect(console.error.mock.calls[0]).toMatchSnapshot()
+            console.error = originalError
+          } catch (e) {
+            console.error(e)
+            throw e
+          }
         }
       },
     },
@@ -295,14 +309,17 @@ pluginTester({
           searchSync: () => null,
         }))
         return function teardown() {
-          const configurableMacro = require('./fixtures/config/configurable.macro')
-          expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
-          expect(configurableMacro.realMacro).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-              config: expect.any,
-            }),
-          )
-          configurableMacro.realMacro.mockClear()
+          try {
+            const configurableMacro = require('./fixtures/config/configurable.macro')
+            expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
+            expect(configurableMacro.realMacro.mock.calls[0][0].config).toEqual(
+              {},
+            )
+            configurableMacro.realMacro.mockClear()
+          } catch (e) {
+            console.error(e)
+            throw e
+          }
         }
       },
     },
@@ -316,18 +333,19 @@ pluginTester({
       },
       fixture: path.join(__dirname, 'fixtures/config/code.js'),
       teardown() {
-        const configurableMacro = require('./fixtures/config/configurable.macro')
-        expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
-        expect(configurableMacro.realMacro).toHaveBeenCalledWith(
-          expect.objectContaining({
-            config: {
-              fileConfig: true,
-              someConfig: false,
-              somePluginConfig: true,
-            },
-          }),
-        )
-        configurableMacro.realMacro.mockClear()
+        try {
+          const configurableMacro = require('./fixtures/config/configurable.macro')
+          expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
+          expect(configurableMacro.realMacro.mock.calls[0][0].config).toEqual({
+            fileConfig: true,
+            someConfig: false,
+            somePluginConfig: true,
+          })
+          configurableMacro.realMacro.mockClear()
+        } catch (e) {
+          console.error(e)
+          throw e
+        }
       },
     },
     {
@@ -336,16 +354,18 @@ pluginTester({
       pluginOptions: {
         configurableMacro: 2,
       },
-      setup() {
-        return function teardown() {
+      teardown() {
+        try {
           const configurableMacro = require('./fixtures/config/configurable.macro')
           expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
-          expect(configurableMacro.realMacro).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-              config: expect.any,
-            }),
-          )
+          expect(configurableMacro.realMacro.mock.calls[0][0].config).toEqual({
+            fileConfig: true,
+            someConfig: true,
+          })
           configurableMacro.realMacro.mockClear()
+        } catch (e) {
+          console.error(e)
+          throw e
         }
       },
     },

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -360,7 +360,7 @@ pluginTester({
           expect(configurableMacro.realMacro).toHaveBeenCalledTimes(1)
           expect(configurableMacro.realMacro.mock.calls[0][0].config).toEqual({
             fileConfig: true,
-            someConfig: false,
+            someConfig: true,
             somePluginConfig: true,
           })
           configurableMacro.realMacro.mockClear()

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,26 @@ class MacroError extends Error {
   }
 }
 
+let _configExplorer = null
+function getConfigExporer() {
+  return (_configExplorer =
+    _configExplorer ||
+    // Lazy load cosmiconfig since it is a relatively large bundle
+    require('cosmiconfig')('babel-plugin-macros', {
+      searchPlaces: [
+        'package.json',
+        '.babel-plugin-macrosrc',
+        '.babel-plugin-macrosrc.json',
+        '.babel-plugin-macrosrc.yaml',
+        '.babel-plugin-macrosrc.yml',
+        '.babel-plugin-macrosrc.js',
+        'babel-plugin-macros.config.js',
+      ],
+      packageProp: 'babelMacros',
+      sync: true,
+    }))
+}
+
 function createMacro(macro, options = {}) {
   if (options.configName === 'options') {
     throw new Error(
@@ -232,19 +252,7 @@ function applyMacros({
 
 function getConfigFromFile(configName, filename) {
   try {
-    const loaded = require('cosmiconfig')('babel-plugin-macros', {
-      searchPlaces: [
-        'package.json',
-        '.babel-plugin-macrosrc',
-        '.babel-plugin-macrosrc.json',
-        '.babel-plugin-macrosrc.yaml',
-        '.babel-plugin-macrosrc.yml',
-        '.babel-plugin-macrosrc.js',
-        'babel-plugin-macros.config.js',
-      ],
-      packageProp: 'babelMacros',
-      sync: true,
-    }).searchSync(filename)
+    const loaded = getConfigExporer().searchSync(filename)
 
     if (loaded) {
       return {

--- a/src/index.js
+++ b/src/index.js
@@ -315,8 +315,8 @@ function getConfig(macro, filename, source, options) {
     }
 
     return {
-      ...fileConfig.options,
       ...optionsConfig.options,
+      ...fileConfig.options,
     }
   }
   return undefined


### PR DESCRIPTION
Fixes #112 

I'm missing test coverage, but I'm also not familiar with the way this test environment is set up. Some tips on how to test this well would be appreciated.