### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
-os:
-  - linux
-  - windows
 sudo: false
 language: node_js
-cache:
-  directories:
-    - ~/.npm
+cache: npm
 notifications:
   email: false
 node_js: '10'
-install: npm install
-script: npm run validate
-after_success: kcd-scripts travis-after-success
+jobs:
+  include:
+    - stage: test
+      os: linux
+      install: npm install
+      script: npm run validate
+      after_success: kcd-scripts travis-after-success
+    - stage: test
+      os: windows
+      install: npm install
+      script: npm run validate
 branches:
   only: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,8 @@ jobs:
       os: windows
       install: npm install
       script: npm run validate
+      # Travis does not support secrets on Windows yet so we test only external PRs where the secrets are not exposed
+      # https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264
+      if: head_repo != "kentcdodds/babel-plugin-macros"
 branches:
   only: master


### PR DESCRIPTION
**What**:

Do not run release step on Windows
Skip Windows CI step if build is not invoked for PR

**Why**:

[Known issue](https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264) with Travis secrets 

**How**:

Skip Windows job if the build is not executed for a PR as it would fail anyway

