### PR TITLE
fix: handle namespace imports gracefully

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -320,7 +320,7 @@ const x = 79;
 
 `;
 
-exports[`macros works with import: works with import 1`] = `
+exports[`macros works with default import: works with default import 1`] = `
 
 import myEval from './fixtures/eval.macro'
 const x = myEval\`34 + 45\`
@@ -328,6 +328,38 @@ const x = myEval\`34 + 45\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const x = 79;
+
+`;
+
+exports[`macros works with namespace import: works with namespace import 1`] = `
+
+import * as foo from './fixtures/namespace-proxy.macro'
+
+export const x = foo.bar(42)
+export const y = foo.baz(42)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _baz from "some-module/dist/baz";
+import _bar from "some-module/dist/bar";
+export const x = _bar(42);
+export const y = _baz(42);
+
+`;
+
+exports[`macros does not distinguish namespace from default import: does not distinguish namespace from default import 1`] = `
+
+import foo from './fixtures/namespace-proxy.macro'
+
+export const x = foo.bar(42)
+export const y = foo.baz(42)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _baz from "some-module/dist/baz";
+import _bar from "some-module/dist/bar";
+export const x = _bar(42);
+export const y = _baz(42);
 
 `;
 

--- a/src/__tests__/fixtures/namespace-proxy.macro.js
+++ b/src/__tests__/fixtures/namespace-proxy.macro.js
@@ -1,0 +1,86 @@
+/*
+  This macro replaces a namespace import with multiple deep imports for each namespace member used
+
+  import * as foo from './fixtures/namespace.macro'
+
+  export const x = foo.bar(42)
+  export const y = foo.baz(42)
+
+        ↓ ↓ ↓ ↓ ↓ ↓
+
+  import _baz from "some-module/dist/baz";
+  import _bar from "some-module/dist/bar";
+  export const x = _bar(42);
+  export const y = _baz(42);
+ */
+
+const {createMacro} = require('../../')
+
+module.exports = createMacro(namespaceProxyMacro)
+
+function namespaceProxyMacro({references, babel}) {
+  const {types} = babel
+
+  forEach(references, (referenceInstances, referenceName) => {
+    if (referenceName !== 'default') {
+      throw new TypeError(`Named imports are not implemented.`)
+    }
+    forEach(referenceInstances, reference => {
+      if (
+        types.isTSQualifiedName(reference.parentPath) ||
+        types.isQualifiedTypeIdentifier(reference.parentPath)
+      ) {
+        return
+      }
+
+      if (
+        !types.isIdentifier(reference) ||
+        !types.isMemberExpression(reference.parentPath)
+      ) {
+        throw new TypeError(
+          `Unexpected context:\n reference type: ${
+            reference.type
+          } parent type: ${reference.parentPath.type} `,
+        )
+      }
+
+      replaceReference(
+        reference,
+        types,
+        types.Identifier,
+        id => `some-module/dist/${id}`,
+      )
+    })
+  })
+}
+
+function forEach(collection, iterator) {
+  if (!collection) {
+    return
+  }
+  if (Array.isArray(collection)) {
+    collection.forEach(iterator)
+  } else {
+    Object.keys(collection).forEach(key =>
+      iterator(collection[key], key, collection),
+    )
+  }
+}
+
+function replaceReference(reference, types, replacementType, proxy) {
+  const name = reference.container.property.name
+  const id = insertImport(reference, types, name, proxy)
+  reference.parentPath.replaceWith(replacementType(id))
+  return id
+}
+
+function insertImport(reference, types, name, proxy) {
+  const {scope} = reference.findParent(path => path.type === 'Program')
+  const identifier = scope.generateUidIdentifier(name)
+  const ast = types.importDeclaration(
+    [types.importDefaultSpecifier(identifier)],
+    types.stringLiteral(proxy(name)),
+  )
+  scope.block.body.unshift(ast)
+  return identifier.name
+}

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -103,10 +103,28 @@ pluginTester({
       `,
     },
     {
-      title: 'works with import',
+      title: 'works with default import',
       code: `
         import myEval from './fixtures/eval.macro'
         const x = myEval\`34 + 45\`
+      `,
+    },
+    {
+      title: 'works with namespace import',
+      code: `
+        import * as foo from './fixtures/namespace-proxy.macro'
+        
+        export const x = foo.bar(42)
+        export const y = foo.baz(42)
+      `,
+    },
+    {
+      title: 'does not distinguish namespace from default import',
+      code: `
+        import foo from './fixtures/namespace-proxy.macro'
+        
+        export const x = foo.bar(42)
+        export const y = foo.baz(42)
       `,
     },
     {

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,16 @@ function macrosPlugin(
     return o && o.__esModule && o.default ? o.default : o
   }
 
+  function getImportedName(specifier) {
+    switch (specifier.type) {
+      case 'ImportNamespaceSpecifier':
+      case 'ImportDefaultSpecifier':
+        return 'default'
+      default:
+        return specifier.imported.name
+    }
+  }
+
   return {
     name: 'macros',
     visitor: {
@@ -94,10 +104,7 @@ function macrosPlugin(
             }
             const imports = path.node.specifiers.map(s => ({
               localName: s.local.name,
-              importedName:
-                s.type === 'ImportDefaultSpecifier'
-                  ? 'default'
-                  : s.imported.name,
+              importedName: getImportedName(s),
             }))
             const source = path.node.source.value
             const result = applyMacros({


### PR DESCRIPTION
**What**:

Fix #111 

**How**:

Handle namespace imports as default imports.

**Why**

Historically default imports are there in es6 only because of  CommonJS interop compatibility and in the context of such an interop (or more broadly any non es module interop) Babel itself populates `default` property in the same way for both namespace and default imports.

```es6
function _interopRequireDefault(obj) {
  return obj && obj.__esModule ? obj : { default: obj };
}

function _interopRequireWildcard(obj) {
  if (obj && obj.__esModule) {
    return obj;
  } else {
    var newObj = {};
    /* ... copy props ... */
    newObj["default"] = obj;
    return newObj;
  }
}
```
If we accept that importing from a macro is not exactly the same thing as consuming an es module and follow a formal logic of Babel it would be justifiable for `babel-plugin-macros` to coerce a namespace import to a default import.
