### PR TITLE
Add CodeFund sponsorship message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <a href="https://codefund.io/properties/448/visit-sponsor">
+    <img src="https://codefund.io/properties/448/sponsor" />
+  </a>
+</p>
+
 <div align="center">
 <h1>babel-plugin-macros 🎣</h1>
 


### PR DESCRIPTION
[CodeFund](https://codefund.io) provides ethical sponsorships to open source maintainers. This PR will place the "Sponsored by" image at the top of the README. The sponsoring companies are not paying per click nor impression. They are paying the maintainer(s) on a per-month basis to be the primary sponsor of this project.