### PR TITLE
Add isMacrosName option

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -214,6 +214,28 @@ Error: The macro imported from "./fixtures/non-wrapped.macro" must be wrapped in
 
 `;
 
+exports[`macros when a custom isMacrosName option is used on a import: when a custom isMacrosName option is used on a import 1`] = `
+
+import myEval from './fixtures/eval-macro.js'
+const x = myEval\`34 + 45\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const x = 79;
+
+`;
+
+exports[`macros when a custom isMacrosName option is used on a require: when a custom isMacrosName option is used on a require 1`] = `
+
+const evaler = require('./fixtures/eval-macro.js')
+const x = evaler\`34 + 45\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const x = 79;
+
+`;
+
 exports[`macros when a plugin that replaces paths is used, macros still work properly: when a plugin that replaces paths is used, macros still work properly 1`] = `
 
 import myEval from '../eval.macro'

--- a/src/__tests__/fixtures/eval-macro.js
+++ b/src/__tests__/fixtures/eval-macro.js
@@ -1,0 +1,1 @@
+module.exports = require('./eval.macro.js')

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -411,6 +411,30 @@ pluginTester({
       },
     },
     {
+      title: 'when a custom isMacrosName option is used on a import',
+      pluginOptions: {
+        isMacrosName(v) {
+          return v.endsWith('-macro.js')
+        },
+      },
+      code: `
+        import myEval from './fixtures/eval-macro.js'
+        const x = myEval\`34 + 45\`
+      `,
+    },
+    {
+      title: 'when a custom isMacrosName option is used on a require',
+      pluginOptions: {
+        isMacrosName(v) {
+          return v.endsWith('-macro.js')
+        },
+      },
+      code: `
+        const evaler = require('./fixtures/eval-macro.js')
+        const x = evaler\`34 + 45\`
+      `,
+    },
+    {
       title:
         'when plugin options configuration cannot be merged with file configuration',
       error: true,

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const resolve = require('resolve')
 // const printAST = require('ast-pretty-print')
 
 const macrosRegex = /[./]macro(\.js)?$/
+const testMacrosRegex = v => macrosRegex.test(v)
 
 // https://stackoverflow.com/a/32749533/971592
 class MacroError extends Error {
@@ -67,7 +68,12 @@ function nodeResolvePath(source, basedir) {
 
 function macrosPlugin(
   babel,
-  {require: _require = require, resolvePath = nodeResolvePath, ...options} = {},
+  {
+    require: _require = require,
+    resolvePath = nodeResolvePath,
+    isMacrosName = testMacrosRegex,
+    ...options
+  } = {},
 ) {
   function interopRequire(path) {
     // eslint-disable-next-line import/no-dynamic-require
@@ -84,7 +90,7 @@ function macrosPlugin(
             const isMacros = looksLike(path, {
               node: {
                 source: {
-                  value: v => macrosRegex.test(v),
+                  value: v => isMacrosName(v),
                 },
               },
             })
@@ -124,7 +130,7 @@ function macrosPlugin(
                       name: 'require',
                     },
                     arguments: args =>
-                      args.length === 1 && macrosRegex.test(args[0].value),
+                      args.length === 1 && isMacrosName(args[0].value),
                   },
                 },
               })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Resolving #131 by adding a new option called `isMacrosName` for the plugin.

<!-- Why are these changes necessary? -->

**Why**: Allows the user to selectively accept modules as a macro for this plugin.

<!-- How were these changes implemented? -->

**How**: This option will optionally overwrite the original behaviour, so backwards compatibility is kept.

<!-- feel free to add additional comments -->
