### PR TITLE
fix: Do not log error message when config is missing

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -88,6 +88,20 @@ MacroError: very helpful
 
 `;
 
+exports[`macros macros can set their configName and get their config: macros can set their configName and get their config 1`] = `
+
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`;
+
+`;
+
 exports[`macros optionally keep imports (import declaration): optionally keep imports (import declaration) 1`] = `
 
 import macro from './fixtures/keep-imports.macro'
@@ -237,6 +251,48 @@ global.result = result;
 
 `;
 
+exports[`macros when configuration is specified in plugin options: when configuration is specified in plugin options 1`] = `
+
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`;
+
+`;
+
+exports[`macros when configuration is specified in plugin options: when configuration is specified in plugin options 2`] = `
+
+const configured = require('./configurable.macro')
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`;
+
+`;
+
+exports[`macros when configuration is specified incorrectly in plugin options: when configuration is specified incorrectly in plugin options 1`] = `
+
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`;
+
+`;
+
 exports[`macros when plugin options configuration cannot be merged with file configuration: when plugin options configuration cannot be merged with file configuration 1`] = `
 
 import configured from './configurable.macro'
@@ -246,7 +302,7 @@ configured\`stuff\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-Error: Cannot find module '../../../../' from 'configurable.macro.js'
+Error: <PROJECT_ROOT>/src/__tests__/fixtures/primitive-config/babel-plugin-macros.config.js specified a configurableMacro config of type object, but the the macros plugin's options.configurableMacro did contain an object. Both configs must contain objects for their options to be mergeable.
 
 `;
 
@@ -254,6 +310,33 @@ exports[`macros when there is an error reading the config, a helpful message is 
 Array [
   There was an error trying to load the config "configurableMacro" for the macro imported from "./configurable.macro. Please see the error thrown for more information.,
 ]
+`;
+
+exports[`macros when there is an error reading the config, a helpful message is logged: when there is an error reading the config, a helpful message is logged 1`] = `
+
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+Error: this is a cosmiconfig error
+
+`;
+
+exports[`macros when there is no config to load, then no config is passed: when there is no config to load, then no config is passed 1`] = `
+
+import configured from './configurable.macro'
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// eslint-disable-next-line babel/no-unused-expressions
+configured\`stuff\`;
+
 `;
 
 exports[`macros works with function calls: works with function calls 1`] = `

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -88,20 +88,6 @@ MacroError: very helpful
 
 `;
 
-exports[`macros macros can set their configName and get their config: macros can set their configName and get their config 1`] = `
-
-import configured from './configurable.macro'
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`;
-
-`;
-
 exports[`macros optionally keep imports (import declaration): optionally keep imports (import declaration) 1`] = `
 
 import macro from './fixtures/keep-imports.macro'
@@ -251,48 +237,6 @@ global.result = result;
 
 `;
 
-exports[`macros when configuration is specified in plugin options: when configuration is specified in plugin options 1`] = `
-
-import configured from './configurable.macro'
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`;
-
-`;
-
-exports[`macros when configuration is specified in plugin options: when configuration is specified in plugin options 2`] = `
-
-const configured = require('./configurable.macro')
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`;
-
-`;
-
-exports[`macros when configuration is specified incorrectly in plugin options: when configuration is specified incorrectly in plugin options 1`] = `
-
-import configured from './configurable.macro'
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`;
-
-`;
-
 exports[`macros when plugin options configuration cannot be merged with file configuration: when plugin options configuration cannot be merged with file configuration 1`] = `
 
 import configured from './configurable.macro'
@@ -302,7 +246,7 @@ configured\`stuff\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-Error: <PROJECT_ROOT>/src/__tests__/fixtures/primitive-config/babel-plugin-macros.config.js specified a configurableMacro config of type object, but the the macros plugin's options.configurableMacro did contain an object. Both configs must contain objects for their options to be mergeable.
+Error: Cannot find module '../../../../' from 'configurable.macro.js'
 
 `;
 
@@ -310,33 +254,6 @@ exports[`macros when there is an error reading the config, a helpful message is 
 Array [
   There was an error trying to load the config "configurableMacro" for the macro imported from "./configurable.macro. Please see the error thrown for more information.,
 ]
-`;
-
-exports[`macros when there is an error reading the config, a helpful message is logged: when there is an error reading the config, a helpful message is logged 1`] = `
-
-import configured from './configurable.macro'
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-Error: this is a cosmiconfig error
-
-`;
-
-exports[`macros when there is no config to load, then no config is passed: when there is no config to load, then no config is passed 1`] = `
-
-import configured from './configurable.macro'
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-// eslint-disable-next-line babel/no-unused-expressions
-configured\`stuff\`;
-
 `;
 
 exports[`macros works with function calls: works with function calls 1`] = `

--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,8 @@ function getConfig(macro, filename, source, options) {
 
     if (
       optionsConfig.options === undefined &&
-      fileConfig.options === undefined
+      fileConfig.options === undefined &&
+      fileConfig.error !== undefined
     ) {
       // eslint-disable-next-line no-console
       console.error(
@@ -302,9 +303,7 @@ function getConfig(macro, filename, source, options) {
           `for the macro imported from "${source}. ` +
           `Please see the error thrown for more information.`,
       )
-      if (fileConfig.error !== undefined) {
-        throw fileConfig.error
-      }
+      throw fileConfig.error
     }
 
     if (


### PR DESCRIPTION
The goal of this PR is to only log the following error messages when they need to be logged:
![image](https://user-images.githubusercontent.com/6616955/69422947-f7488280-0d5f-11ea-9148-3ed0609965df.png)

They happen when no config is specified (either in babel or via cosmoconfig). Most babel macros work perfectly well without config so this message is incorrect and the macro itself should throw if the config is missing.

Moreover, the error message states: `Please see the error thrown for more information.` but no error is thrown. I've written in this PR what I believe is the expected behavior.

Related:
- https://github.com/facebook/create-react-app/issues/7524
- https://github.com/styled-components/styled-components/issues/2713