### PR TITLE
feat(resolve): add fallback path to be able to resolve modules relatively to `babel-plugin-macros`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,8 @@ function createMacro(macro, options = {}) {
 function nodeResolvePath(source, basedir) {
   return resolve.sync(source, {
     basedir,
+    // This is here to support the package being globally installed
+    // read more: https://github.com/kentcdodds/babel-plugin-macros/pull/138
     paths: [p.resolve(__dirname, '../../')]
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,10 @@ function createMacro(macro, options = {}) {
 }
 
 function nodeResolvePath(source, basedir) {
-  return resolve.sync(source, {basedir})
+  return resolve.sync(source, {
+    basedir,
+    paths: [p.resolve(__dirname, '../../')]
+  })
 }
 
 function macrosPlugin(


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: https://github.com/kentcdodds/babel-plugin-macros/issues/87

<!-- Why are these changes necessary? -->

**Why**: In case you have `babel-plugin-macros` loaded outside of `process.cwd()` it cannot resolve modules realtively to itself.

<!-- How were these changes implemented? -->

**How**: Added the node_modules folder including `babel-plugin-macros` as a fallback path.

<!-- feel free to add additional comments -->
