### PR TITLE
use babel traverse

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
+    "@babel/traverse": "^7.10.1",
     "cosmiconfig": "^6.0.0",
     "resolve": "^1.15.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -229,7 +229,6 @@ function applyMacros({
      *
      * See: https://github.com/kentcdodds/import-all.macro/issues/7
      */
-    console.log(state.file.ast);
     traverse(state.file.ast, {
       Identifier() {},
     });

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const p = require('path')
 const resolve = require('resolve')
+const traverse = require("@babel/traverse").default;
 // const printAST = require('ast-pretty-print')
 
 const macrosRegex = /[./]macro(\.js)?$/
@@ -228,9 +229,10 @@ function applyMacros({
      *
      * See: https://github.com/kentcdodds/import-all.macro/issues/7
      */
-    state.file.scope.path.traverse({
+    console.log(state.file.ast);
+    traverse(state.file.ast, {
       Identifier() {},
-    })
+    });
 
     result = macro({
       references: referencePathsByImportName,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const p = require('path')
 const resolve = require('resolve')
-const traverse = require("@babel/traverse").default;
+const traverse = require("@babel/traverse").default
 // const printAST = require('ast-pretty-print')
 
 const macrosRegex = /[./]macro(\.js)?$/
@@ -231,7 +231,7 @@ function applyMacros({
      */
     traverse(state.file.ast, {
       Identifier() {},
-    });
+    })
 
     result = macro({
       references: referencePathsByImportName,


### PR DESCRIPTION
Resolves: https://github.com/kentcdodds/babel-plugin-macros/issues/121

This uses [`@babel/traverse`](https://babeljs.io/docs/en/babel-traverse) rather than the stateful one