### PR TITLE
Allow macros to end in .cjs

### DIFF
--- a/other/docs/author.md
+++ b/other/docs/author.md
@@ -56,15 +56,17 @@ There are two parts to the `babel-plugin-macros` API:
 
 The way that `babel-plugin-macros` determines whether to run a macro is based on
 the source string of the `import` or `require` statement. It must match this
-regex: `/[./]macro(\.js)?$/` for example:
+regex: `/[./]macro(\.c?js)?$/` for example:
 
 _matches_:
 
 ```
 'my.macro'
 'my.macro.js'
+'my.macro.cjs'
 'my/macro'
 'my/macro.js'
+'my/macro.cjs'
 ```
 
 _does not match_:
@@ -305,8 +307,8 @@ Contributions to improve this experience are definitely welcome!
 
 ## Async logic
 
-Unfortunately, babel plugins are synchronous so you can't do anything asynchronous
-with `babel-plugin-macros`. However, you can cheat a bit by running
+Unfortunately, babel plugins are synchronous so you can't do anything
+asynchronous with `babel-plugin-macros`. However, you can cheat a bit by running
 `child_process`'s `spawnSync` to synchronously execute a file. It's definitely a
 hack and is not great for performance, but in most cases it's fast enough™️.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 const p = require('path')
 const resolve = require('resolve')
-const traverse = require("@babel/traverse").default
+const traverse = require('@babel/traverse').default
 // const printAST = require('ast-pretty-print')
 
-const macrosRegex = /[./]macro(\.js)?$/
+const macrosRegex = /[./]macro(\.c?js)?$/
 const testMacrosRegex = v => macrosRegex.test(v)
 
 // https://stackoverflow.com/a/32749533/971592


### PR DESCRIPTION
When a macro is defined in a package with `"type": "module"` set in `package.json`, `babel-plugin-macros` uses `require` to load it. This fails because require is not allowed on an es module (which the macro is now assumed to be). The answer for the moment is for the macro not to be a module, which requires that its extension be `macro.cjs` and that it be imported with an explicit extension. This change ensures that that is possible.