### PR TITLE
support more extensions that babel macros can be written in

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ function createMacro(macro, options = {}) {
 function nodeResolvePath(source, basedir) {
   return resolve.sync(source, {
     basedir,
-    extensions: ['.js', '.ts', '.tsx', '.mjs'],
+    extensions: ['.js', '.ts', '.tsx', '.mjs', '.cjs', '.jsx'],
     // This is here to support the package being globally installed
     // read more: https://github.com/kentcdodds/babel-plugin-macros/pull/138
     paths: [p.resolve(__dirname, '../../')],

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ function createMacro(macro, options = {}) {
 function nodeResolvePath(source, basedir) {
   return resolve.sync(source, {
     basedir,
+    extensions: ['.js', '.ts', '.tsx', '.mjs'],
     // This is here to support the package being globally installed
     // read more: https://github.com/kentcdodds/babel-plugin-macros/pull/138
     paths: [p.resolve(__dirname, '../../')],


### PR DESCRIPTION
**What**:

Babel macros that are written in typescript and not transpiled prior to being run through `babel-plugin-macros` are currently not detected because `resolve` defaults to only looking for the `".js"` extension.
