### PR TITLE
refactor: replace cosmiconfig with lilconfig

### DIFF
--- a/other/docs/author.md
+++ b/other/docs/author.md
@@ -183,9 +183,9 @@ To specify that your plugin is configurable, you pass a `configName` to
 `createMacro`.
 
 A configuration is created from data combined from two sources: We use
-[`cosmiconfig`][cosmiconfig] to read a `babel-plugin-macros` configuration which
-can be located in any of the following files up the directories from the
-importing file:
+[`lilconfig`][lilconfig] to read a `babel-plugin-macros` configuration which can
+be located in any of the following files up the directories from the importing
+file:
 
 - `.babel-plugin-macrosrc`
 - `.babel-plugin-macrosrc.json`
@@ -210,14 +210,13 @@ module.exports = {
 module.exports = {
   plugins: [
     [
-      "macros",
+      'macros',
       {
-        taggedTranslations: { locale: "en_GB" },
+        taggedTranslations: {locale: 'en_GB'},
       },
     ],
   ],
 }
-
 
 // taggedTranslations.macro.js
 const {createMacro} = require('babel-plugin-macros')
@@ -343,4 +342,4 @@ function myMacro({references, state, babel}) {
 [keyword]: https://docs.npmjs.com/files/package.json#keywords
 [npm-babel-plugin-macros]:
   https://www.npmjs.com/browse/keyword/babel-plugin-macros
-[cosmiconfig]: https://www.npmjs.com/package/cosmiconfig
+[lilconfig]: https://www.npmjs.com/package/lilconfig

--- a/other/docs/user.md
+++ b/other/docs/user.md
@@ -97,9 +97,9 @@ $ yarn upgrade react-scripts
 ### config
 
 There is a feature that allows you to configure your macro. We use
-[`cosmiconfig`][cosmiconfig] to read a `babel-plugin-macros` configuration which
-can be located in any of the following files up the directories from the
-importing file:
+[`lilconfig`][lilconfig] to read a `babel-plugin-macros` configuration which can
+be located in any of the following files up the directories from the importing
+file:
 
 - `.babel-plugin-macrosrc`
 - `.babel-plugin-macrosrc.json`
@@ -123,5 +123,5 @@ module.exports = {
 }
 ```
 
-[cosmiconfig]: https://www.npmjs.com/package/cosmiconfig
+[lilconfig]: https://www.npmjs.com/package/lilconfig
 [styled-components]: https://www.styled-components.com/docs/tooling#babel-macro

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "cosmiconfig": "^7.0.0",
-    "resolve": "^1.19.0"
+    "lilconfig": "^2.0.4",
+    "resolve": "^1.19.0",
+    "yaml": "^1.10.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -343,7 +343,7 @@ configured\`stuff\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-Error: this is a cosmiconfig error
+Error: this is a lilconfig error
 
 `;
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import {cosmiconfigSync as cosmiconfigSyncMock} from 'cosmiconfig'
+import {lilconfigSync as lilconfigSyncMock} from 'lilconfig'
 import cpy from 'cpy'
 import babel from '@babel/core'
 import pluginTester from 'babel-plugin-tester'
@@ -7,14 +7,14 @@ import plugin from '../'
 
 const projectRoot = path.join(__dirname, '../../')
 
-jest.mock('cosmiconfig', () => {
-  const cosmiconfigExports = jest.requireActual('cosmiconfig')
-  const actualCosmiconfigSync = cosmiconfigExports.cosmiconfigSync
-  function fakeCosmiconfigSync(...args) {
-    fakeCosmiconfigSync.explorer = actualCosmiconfigSync(...args)
-    return fakeCosmiconfigSync.explorer
+jest.mock('lilconfig', () => {
+  const lilconfigExports = jest.requireActual('lilconfig')
+  const actualLilconfigSync = lilconfigExports.lilconfigSync
+  function fakeLilconfigSync(...args) {
+    fakeLilconfigSync.explorer = actualLilconfigSync(...args)
+    return fakeLilconfigSync.explorer
   }
-  return {...cosmiconfigExports, cosmiconfigSync: fakeCosmiconfigSync}
+  return {...lilconfigExports, lilconfigSync: fakeLilconfigSync}
 })
 
 beforeAll(() => {
@@ -296,9 +296,9 @@ pluginTester({
       fixture: path.join(__dirname, 'fixtures/config/code.js'),
       setup() {
         jest
-          .spyOn(cosmiconfigSyncMock.explorer, 'search')
+          .spyOn(lilconfigSyncMock.explorer, 'search')
           .mockImplementationOnce(() => {
-            throw new Error('this is a cosmiconfig error')
+            throw new Error('this is a lilconfig error')
           })
         jest.spyOn(console, 'error').mockImplementationOnce(() => {})
         return function teardown() {
@@ -319,7 +319,7 @@ pluginTester({
       fixture: path.join(__dirname, 'fixtures/config/code.js'),
       setup() {
         jest
-          .spyOn(cosmiconfigSyncMock.explorer, 'search')
+          .spyOn(lilconfigSyncMock.explorer, 'search')
           .mockImplementationOnce(() => {
             return null
           })

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ const p = require('path')
 const resolve = require('resolve')
 // const printAST = require('ast-pretty-print')
 
+const {lilconfigSync} = require('lilconfig')
+
 const macrosRegex = /[./]macro(\.c?js)?$/
 const testMacrosRegex = v => macrosRegex.test(v)
 
@@ -19,12 +21,17 @@ class MacroError extends Error {
   }
 }
 
+function loadYaml(filepath, content) {
+  // Lazy load yaml since it is a relatively large bundle
+  const yaml = require('yaml')
+  return yaml.parse(content)
+}
+
 let _configExplorer = null
 function getConfigExplorer() {
   return (_configExplorer =
     _configExplorer ||
-    // Lazy load cosmiconfig since it is a relatively large bundle
-    require('cosmiconfig').cosmiconfigSync('babel-plugin-macros', {
+    lilconfigSync('babel-plugin-macros', {
       searchPlaces: [
         'package.json',
         '.babel-plugin-macrosrc',
@@ -35,6 +42,12 @@ function getConfigExplorer() {
         'babel-plugin-macros.config.js',
       ],
       packageProp: 'babelMacros',
+      loaders: {
+        '.yaml': loadYaml,
+        '.yml': loadYaml,
+        // loader for files with no extension
+        noExt: loadYaml,
+      },
     }))
 }
 


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

cosmiconfig is a massive package which recently got a small alternative
without dependencies lilconfig.

https://github.com/antonk52/lilconfig

https://packagephobia.com/result?p=cosmiconfig
https://packagephobia.com/result?p=lilconfig

Though still a big part of cosmiconfig is `yaml` package.
https://packagephobia.com/result?p=yaml

This package is important piece of [relay](https://github.com/facebook/relay/blob/378104f341c0682dbad646221db34fc5e0ce41c9/packages/babel-plugin-relay/package.json#L16) and [emotion](https://github.com/emotion-js/emotion/blob/242f7d8c9f3ddbba2a69664bcc0fa22501df849f/packages/babel-plugin/package.json#L22). Would be good to make it as small as possible.


**Why**:

Node modules are bloated with large dependencies. I'm trying to help with this.

**How**:

Just switch to alternative.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
